### PR TITLE
translate: could not load message from disk

### DIFF
--- a/src/bitmessageqt/__init__.py
+++ b/src/bitmessageqt/__init__.py
@@ -3873,7 +3873,7 @@ class MyForm(settingsmixin.SMainWindow):
         else:
             data = self.getCurrentMessageId()
             if data != False:
-                message = "Error occurred: could not load message from disk."
+                message = "Error occurred: could not load message from disk." #### TODO: _translate( this ! happens frequently
         messageTextedit.setCurrentFont(QtGui.QFont())
         messageTextedit.setTextColor(QtGui.QColor())
         messageTextedit.setContent(message)


### PR DESCRIPTION
message = "Error occurred: could not load message from disk." 
TODO: _translate( this ! 
it happens frequently. my suggestion:

"Error occurred: could not load message from disk. -- This is not a (received) BitMessage, but an error message due to a read storage problem."

## Code contributions to the Bitmessage project

- try to explain what the code is about
- try to follow [PEP0008](https://www.python.org/dev/peps/pep-0008/)
- make the pull request against the ["v0.6" branch](https://github.com/Bitmessage/PyBitmessage/tree/v0.6)
- it should be possible to do a fast-forward merge of the pull requests
- PGP-sign the commits included in the pull request
- You can get paid for merged commits if you register at [Tip4Commit](https://tip4commit.com/github/Bitmessage/PyBitmessage)

If for some reason you don't want to use github, you can submit the patch using Bitmessage to the "bitmessage" chan, or to one of the developers.
## Translations

For helping with translations, please use [Transifex](https://www.transifex.com/bitmessage-project/pybitmessage/). There is no need to submit pull requests for translations.
For translating technical terms it is recommended to consult the [Microsoft Language Portal](https://www.microsoft.com/Language/en-US/Default.aspx).